### PR TITLE
Tidy Linux build changes

### DIFF
--- a/src/Sigil/CMakeLists.txt
+++ b/src/Sigil/CMakeLists.txt
@@ -973,7 +973,6 @@ if( UNIX AND NOT APPLE )
     set( LINUX_LAUNCH_INSTALL_SCRIPT_CONFIGURED ${CMAKE_BINARY_DIR}/sigil-sh_install_configured )
     set( LINUX_LAUNCH_PKG_SCRIPT_CONFIGURED ${CMAKE_BINARY_DIR}/sigil-sh_pkg_configured )
     set( SIGIL_EXECUTABLE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX} )
-    set( DESTINATION_EXECUTABLE_NAME ${PROJECT_NAME}-real )
 
     # Specify platform var for dpkg-deb
     if ( 64_BIT_PLATFORM )
@@ -1026,98 +1025,98 @@ if( UNIX AND NOT APPLE )
 
     # Copy Qt runtime libs
     set( QT_LIBS Qt5Concurrent Qt5Core Qt5DBus Qt5Gui Qt5Network Qt5OpenGL Qt5Multimedia Qt5MultimediaWidgets Qt5Positioning Qt5PrintSupport Qt5Qml Qt5Quick Qt5Sensors Qt5Sql Qt5Svg Qt5WebChannel Qt5WebKit Qt5WebKitWidgets Qt5Widgets Qt5Xml Qt5XmlPatterns )
-    add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/ )
+    add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/ )
     foreach( lib ${QT_LIBS} )
 	find_package( ${lib} )
 	string( REPLACE "Qt5" "" classname ${lib} )
 	get_target_property( location Qt5::${classname} LOCATION_Release )
-        add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/lib${lib}.so.5 )
+        add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/lib${lib}.so.5 )
     endforeach( lib)
     
     # Copy ICU libs
     set( QT_ICU_LIBS icudata icui18n icuuc )
-    add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/ )
+    add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/ )
     foreach( lib ${QT_ICU_LIBS} )
         set( location location-NOTFOUND )
         find_file( location lib${lib}.so.53 PATHS ${QT_LIBRARY_DIR} )
-        add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/ )
+        add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/ )
     endforeach( lib )
 
     # Copy iconengines plugins
     set( QT_ICONENGINES qsvgicon )
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/iconengines/ )
+                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/iconengines/ )
     foreach( lib ${QT_ICONENGINES} )
         set( location location-NOTFOUND )
         find_file( location lib${lib}.so PATHS ${QT_PLUGINS_DIR}/iconengines/ )
 	add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/iconengines/ )
+                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/iconengines/ )
     endforeach( lib )    
 
     # Copy imageformats plugins
     set( QT_IMAGEFORMATS qgif qico qjpeg qmng qsvg qtiff qtga qwbmp )
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/imageformats/ )
+                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/imageformats/ )
     foreach( lib ${QT_IMAGEFORMATS} )   
         set( location location-NOTFOUND )
         find_file( location lib${lib}.so PATHS ${QT_PLUGINS_DIR}/imageformats/ )
         add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/imageformats/ )
+                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/imageformats/ )
     endforeach( lib )
 
     # Copy platform plugins
     set( QT_PLATFORMS qminimal qxcb qoffscreen qminimalegl qlinuxfb qeglfs)
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/platforms/ )
+                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/platforms/ )
     foreach( lib ${QT_PLATFORMS} )   
         set( location location-NOTFOUND )
         find_file( location lib${lib}.so PATHS ${QT_PLUGINS_DIR}/platforms/ )
         add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/platforms/ )
+                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/platforms/ )
     endforeach( lib )
         
     # Copy platformtheme plugins
     set( QT_PLATFORMTHEMES qgtk2)
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/platformthemes/ )
+                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/platformthemes/ )
     foreach( lib ${QT_PLATFORMTHEMES} )   
         set( location location-NOTFOUND )
         find_file( location lib${lib}.so PATHS ${QT_PLUGINS_DIR}/platformthemes/ )
         add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/platformthemes/ )
+                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/platformthemes/ )
     endforeach( lib )
     
     # Copy platforminputcontexts plugins
     set( QT_PLATFORMINPUTCONTEXTS composeplatforminputcontextplugin ibusplatforminputcontextplugin)
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/platforminputcontexts/ )
+                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/platforminputcontexts/ )
     foreach( lib ${QT_PLATFORMINPUTCONTEXTS} )   
         set( location location-NOTFOUND )
         find_file( location lib${lib}.so PATHS ${QT_PLUGINS_DIR}/platforminputcontexts/ )
         add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/platforminputcontexts/ )
+                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/platforminputcontexts/ )
     endforeach( lib )
 
     # Copy printsupport plugins
     set( QT_PRINTSUPPORT cupsprintersupport )
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/printsupport/ )
+                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/printsupport/ )
     foreach( lib ${QT_PRINTSUPPORT} )   
         set( location location-NOTFOUND )
         find_file( location lib${lib}.so PATHS ${QT_PLUGINS_DIR}/printsupport/ )
         add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/printsupport/ )
+                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/printsupport/ )
     endforeach( lib )
 
     # Copy sqldrivers plugins
     set( QT_SQLDRIVERS qsqlite qsqlmysql qsqlpsql )
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/share/sigil/sqldrivers/ )
+                        COMMAND cmake -E make_directory ${DEB_TREE_ROOT}/lib/sigil/sqldrivers/ )
     foreach( lib ${QT_SQLDRIVERS} )   
         set( location location-NOTFOUND )
         find_file( location lib${lib}.so PATHS ${QT_PLUGINS_DIR}/sqldrivers/ )
         add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
-                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/share/sigil/sqldrivers/ )
+                            COMMAND cmake -E copy ${location} ${DEB_TREE_ROOT}/lib/sigil/sqldrivers/ )
     endforeach( lib )
 
     # Copy the translation qm files
@@ -1160,7 +1159,7 @@ if( UNIX AND NOT APPLE )
 
     # Copy the application executable
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD 
-                        COMMAND cmake -E copy ${SIGIL_EXECUTABLE} ${DEB_TREE_ROOT}/lib/sigil/${DESTINATION_EXECUTABLE_NAME} )
+                        COMMAND cmake -E copy ${SIGIL_EXECUTABLE} ${DEB_TREE_ROOT}/lib/sigil/ )
 
     # Copy the Unix launcher that sets the proper environment variables before launching the real Sigil binary
     add_custom_command( TARGET ${TARGET_FOR_COPY} PRE_BUILD
@@ -1201,7 +1200,7 @@ if( UNIX AND NOT APPLE )
 
     # Standard Linux 'make install'
     install( PROGRAMS ${LINUX_LAUNCH_INSTALL_SCRIPT_CONFIGURED} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/ RENAME ${PROJECT_NAME} )
-    install( PROGRAMS ${SIGIL_EXECUTABLE} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/sigil/ RENAME ${DESTINATION_EXECUTABLE_NAME} )
+    install( PROGRAMS ${SIGIL_EXECUTABLE} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/sigil/ )
     install( FILES ${LINUX_DESKTOP_FILE} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications/ )
     install( FILES ${LINUX_DESKTOP_ICON_FILE} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pixmaps RENAME sigil.png )
     install( FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/sigil/translations/ )

--- a/src/Sigil/Misc/EmbeddedPython.cpp
+++ b/src/Sigil/Misc/EmbeddedPython.cpp
@@ -31,6 +31,7 @@
 #include <QStandardPaths>
 #include <QDir>
 #include "Misc/Utility.h"
+#include "sigil_constants.h"
 
 /**
  * Possibly Useful QMetaTypes::Type types

--- a/src/Sigil/Misc/PluginDB.cpp
+++ b/src/Sigil/Misc/PluginDB.cpp
@@ -29,6 +29,7 @@
 #include "Misc/PluginDB.h"
 #include "Misc/SettingsStore.h"
 #include "Misc/Utility.h"
+#include "sigil_constants.h"
 
 PluginDB *PluginDB::m_instance = 0;
 
@@ -84,10 +85,10 @@ QString PluginDB::launcherRoot()
 #elif !defined(Q_OS_WIN32) && !defined(Q_OS_MAC)
     // user supplied environment variable to plugin launcher directory will overrides everything
     if (!sigil_extra_root.isEmpty()) {
-        launcher_root = sigil_extra_root += "/plugin_launchers/";
+        launcher_root = sigil_extra_root + "/plugin_launchers/";
     } else {
-        launcher_roots += QCoreApplication::applicationDirPath() + "/../../share/sigil/plugin_launchers/";
-        launcher_roots += QCoreApplication::applicationDirPath() + "/../share/sigil/plugin_launchers/";
+        launcher_roots.append(QCoreApplication::applicationDirPath() + "/../../share/sigil/plugin_launchers/");
+        launcher_roots.append(QCoreApplication::applicationDirPath() + "/../share/sigil/plugin_launchers/");
     }
 #endif
 

--- a/src/Sigil/Misc/SpellCheck.cpp
+++ b/src/Sigil/Misc/SpellCheck.cpp
@@ -35,6 +35,7 @@
 #include "Misc/SpellCheck.h"
 #include "Misc/SettingsStore.h"
 #include "Misc/Utility.h"
+#include "sigil_constants.h"
 
 #if !defined(Q_OS_WIN32) && !defined(Q_OS_MAC)
 # include <stdlib.h>

--- a/src/Sigil/Resource_Files/bash/sigil-sh_install
+++ b/src/Sigil/Resource_Files/bash/sigil-sh_install
@@ -11,21 +11,13 @@ else
   LD_LIBRARY_PATH="$QTLIB_DIR:$LD_LIBRARY_PATH"
 fi
 
-# Create an environment var for SIGIL_PLUGIN_LAUNCHERS
-# since we've relocated the "real" sigil binary.
-if [ -z "$SIGIL_PLUGIN_LAUNCHERS" ]; then
-  SIGIL_PLUGIN_LAUNCHERS="${CMAKE_INSTALL_PREFIX}/share/sigil/plugin_launchers"
-  export SIGIL_PLUGIN_LAUNCHERS
-fi
-
-# Create env var for SIGIL_EMBEDDED_PYTHON_CODE
-if [ -z "$SIGIL_EMBEDDED_PYTHON_CODE" ]; then
-  SIGIL_EMBEDDED_PYTHON_CODE="${CMAKE_INSTALL_PREFIX}/share/sigil/python3lib"
-  export SIGIL_EMBEDDED_PYTHON_CODE
+# Create an environment var for the Sigil helper directory.
+if [ -z "$SIGIL_EXTRA_ROOT" ]; then
+  SIGIL_EXTRA_ROOT="${CMAKE_INSTALL_PREFIX}/share/sigil"
+  export SIGIL_EXTRA_ROOT
 fi
 
 export LD_LIBRARY_PATH
-#export QT_DEBUG_PLUGINS=1 
 
-exec ${CMAKE_INSTALL_PREFIX}/lib/sigil/${DESTINATION_EXECUTABLE_NAME} "$@"
+exec ${CMAKE_INSTALL_PREFIX}/lib/sigil/sigil "$@"
 

--- a/src/Sigil/Resource_Files/bash/sigil-sh_pkg
+++ b/src/Sigil/Resource_Files/bash/sigil-sh_pkg
@@ -3,7 +3,7 @@
 # Entry point for Sigil on Unix systems.
 # Adds the package's bin directory to the LD_LIBRARY_PATH
 
-QTLIB_DIR="${CMAKE_INSTALL_PREFIX}/share/sigil"
+QTLIB_DIR="${CMAKE_INSTALL_PREFIX}/lib/sigil"
 
 if [ -z "$LD_LIBRARY_PATH" ]; then
   LD_LIBRARY_PATH="$QTLIB_DIR"
@@ -11,13 +11,13 @@ else
   LD_LIBRARY_PATH="$QTLIB_DIR:$LD_LIBRARY_PATH"
 fi
 
-# Create an environment var for SIGIL_PLUGIN_LAUNCHERS
-# since we've relocated the "real" sigil binary.
+# Create an environment var for the Sigil helper directory.
 if [ -z "$SIGIL_EXTRA_ROOT" ]; then
-  SIGIL_EXTRA_ROOT="$QTLIB_DIR"
+  SIGIL_EXTRA_ROOT="${CMAKE_INSTALL_PREFIX}/share/sigil"
   export SIGIL_EXTRA_ROOT
 fi
+
 export LD_LIBRARY_PATH
 
-exec ${CMAKE_INSTALL_PREFIX}/lib/sigil/${DESTINATION_EXECUTABLE_NAME} "$@"
+exec ${CMAKE_INSTALL_PREFIX}/lib/sigil/sigil "$@"
 

--- a/src/Sigil/sigil_constants.cpp
+++ b/src/Sigil/sigil_constants.cpp
@@ -2,5 +2,5 @@
 #include "sigil_constants.h"
 
 #if !defined(_WIN32) && !defined(__APPLE__)
-sigil_extra_root = QString(getenv("SIGIL_EXTRA_ROOT"));
+extern const QString sigil_extra_root = QString(getenv("SIGIL_EXTRA_ROOT"));
 #endif


### PR DESCRIPTION
Tidied up a few things with the Linux binary relocation and package building and the SIGIL_EXTRA_ROOT env variable changes.

launch script = install_base/bin/sigil
sigil binary =  install_base/lib/sigil/sigil

QT libs to install_base/lib/sigil/ when binary package is built.

Launch scripts adjusted and tidied.

Fixed a few Linux compilation issues related to the addition of sigil_constants.cpp.