### PR TITLE
Include for MSCV to recognize std::bind

### DIFF
--- a/src/Sigil/BookManipulation/Headings.cpp
+++ b/src/Sigil/BookManipulation/Headings.cpp
@@ -20,6 +20,7 @@
 *************************************************************************/
 
 #include <memory>
+#include <functional>
 
 #include <QtCore/QtCore>
 #include <QtCore/QString>

--- a/src/Sigil/Importers/ImportHTML.cpp
+++ b/src/Sigil/Importers/ImportHTML.cpp
@@ -20,6 +20,7 @@
 *************************************************************************/
 
 #include <memory>
+#include <functional>
 
 #include <QtCore/QtCore>
 #include <QtCore/QDir>

--- a/src/Sigil/SourceUpdates/AnchorUpdates.cpp
+++ b/src/Sigil/SourceUpdates/AnchorUpdates.cpp
@@ -20,6 +20,7 @@
 *************************************************************************/
 
 #include <memory>
+#include <functional>
 
 #include "Misc/EmbeddedPython.h"
 #include <QtCore/QtCore>

--- a/src/Sigil/SourceUpdates/LinkUpdates.cpp
+++ b/src/Sigil/SourceUpdates/LinkUpdates.cpp
@@ -20,6 +20,8 @@
 **
 *************************************************************************/
 
+#include <functional>
+
 #include <QtCore/QtCore>
 #include <QtCore/QString>
 #include <QtConcurrent/QtConcurrent>

--- a/src/Sigil/SourceUpdates/UniversalUpdates.cpp
+++ b/src/Sigil/SourceUpdates/UniversalUpdates.cpp
@@ -20,6 +20,7 @@
 *************************************************************************/
 
 #include <memory>
+#include <functional>
 
 #include <QtCore/QtCore>
 #include <QtCore/QFutureSynchronizer>

--- a/src/Sigil/SourceUpdates/WordUpdates.cpp
+++ b/src/Sigil/SourceUpdates/WordUpdates.cpp
@@ -19,6 +19,8 @@
 **
 *************************************************************************/
 
+#include <functional>
+
 #include <QtCore/QtCore>
 #include <QtCore/QString>
 #include <QtConcurrent/QtConcurrent>


### PR DESCRIPTION
Hey John,

MSVC seems to need &lt;functional&gt; included in the places you replaced boost::bind with std::bind

With that change, can now build and run the master branch on Linux and Windows (VS2013)