### PR TITLE
Capitalize pcre directory name in the source code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -329,12 +329,12 @@ set( MISC_EDITORS_FILES
     )
 
 set( SPCRE_FILES
-    PCRE/SPCRE.cpp
-    PCRE/SPCRE.h
-    PCRE/PCRECache.cpp
-    PCRE/PCRECache.h
-    PCRE/PCREReplaceTextBuilder.cpp
-    PCRE/PCREReplaceTextBuilder.h
+    pcre/SPCRE.cpp
+    pcre/SPCRE.h
+    pcre/PCRECache.cpp
+    pcre/PCRECache.h
+    pcre/PCREReplaceTextBuilder.cpp
+    pcre/PCREReplaceTextBuilder.h
     )
 
 set( VIEW_EDITOR_FILES

--- a/src/Misc/SearchOperations.cpp
+++ b/src/Misc/SearchOperations.cpp
@@ -29,7 +29,7 @@
 #include "Misc/SearchOperations.h"
 #include "Misc/SettingsStore.h"
 #include "Misc/Utility.h"
-#include "PCRE/PCRECache.h"
+#include "pcre/PCRECache.h"
 #include "Misc/HTMLSpellCheck.h"
 #include "ResourceObjects/HTMLResource.h"
 #include "ResourceObjects/TextResource.h"

--- a/src/ViewEditors/BookViewEditor.cpp
+++ b/src/ViewEditors/BookViewEditor.cpp
@@ -48,7 +48,7 @@
 #include "Misc/SettingsStore.h"
 #include "Misc/Utility.h"
 #include "Misc/OpenExternally.h"
-#include "PCRE/PCRECache.h"
+#include "pcre/PCRECache.h"
 #include "sigil_constants.h"
 #include "sigil_exception.h"
 #include "ViewEditors/BookViewEditor.h"

--- a/src/ViewEditors/BookViewPreview.cpp
+++ b/src/ViewEditors/BookViewPreview.cpp
@@ -32,7 +32,7 @@
 #include "Misc/GumboInterface.h"
 #include "Misc/SettingsStore.h"
 #include "Misc/Utility.h"
-#include "PCRE/PCRECache.h"
+#include "pcre/PCRECache.h"
 #include "sigil_constants.h"
 #include "ViewEditors/BookViewPreview.h"
 #include "ViewEditors/ViewWebPage.h"

--- a/src/ViewEditors/CodeViewEditor.cpp
+++ b/src/ViewEditors/CodeViewEditor.cpp
@@ -50,7 +50,7 @@
 #include "Misc/SpellCheck.h"
 #include "Misc/HTMLSpellCheck.h"
 #include "Misc/Utility.h"
-#include "PCRE/PCRECache.h"
+#include "pcre/PCRECache.h"
 #include "ViewEditors/CodeViewEditor.h"
 #include "ViewEditors/LineNumberArea.h"
 #include "sigil_constants.h"

--- a/src/ViewEditors/Searchable.h
+++ b/src/ViewEditors/Searchable.h
@@ -24,7 +24,7 @@
 #ifndef SEARCHABLE_H
 #define SEARCHABLE_H
 
-#include "PCRE/SPCRE.h"
+#include "pcre/SPCRE.h"
 
 class QString;
 class QStringList;

--- a/src/pcre/PCRECache.cpp
+++ b/src/pcre/PCRECache.cpp
@@ -19,7 +19,7 @@
 **
 *************************************************************************/
 
-#include "PCRE/PCRECache.h"
+#include "pcre/PCRECache.h"
 
 PCRECache *PCRECache::m_instance = 0;
 

--- a/src/pcre/PCRECache.h
+++ b/src/pcre/PCRECache.h
@@ -27,7 +27,7 @@
 #include <QtCore/QCache>
 #include <QtCore/QString>
 
-#include "PCRE/SPCRE.h"
+#include "pcre/SPCRE.h"
 
 /**
  * Singleton. A cache of SPCRE regular expression objects.

--- a/src/pcre/PCREReplaceTextBuilder.cpp
+++ b/src/pcre/PCREReplaceTextBuilder.cpp
@@ -21,7 +21,7 @@
 
 #include <QtCore/QChar>
 
-#include "PCRE/PCREReplaceTextBuilder.h"
+#include "pcre/PCREReplaceTextBuilder.h"
 #include "Misc/Utility.h"
 
 #define is_hex(a) (((a) >= '0' && (a) <= '9') || ((a) >= 'a' && (a) <= 'f') || ((a) >= 'A' && (a) <= 'F') ? true : false)

--- a/src/pcre/PCREReplaceTextBuilder.h
+++ b/src/pcre/PCREReplaceTextBuilder.h
@@ -26,7 +26,7 @@
 
 #include <QtCore/QString>
 
-#include "PCRE/SPCRE.h"
+#include "pcre/SPCRE.h"
 
 class QChar;
 

--- a/src/pcre/SPCRE.cpp
+++ b/src/pcre/SPCRE.cpp
@@ -19,8 +19,8 @@
 **
 *************************************************************************/
 
-#include "PCRE/SPCRE.h"
-#include "PCRE/PCREReplaceTextBuilder.h"
+#include "pcre/SPCRE.h"
+#include "pcre/PCREReplaceTextBuilder.h"
 #include "sigil_constants.h"
 
 // The maximum number of catpures that we will allow.


### PR DESCRIPTION
Without this change (or without changing the capitalization of the `pcre` directory in the source), compiling will fail on case-sensitive filesystems.

Please consider applying this patch (or something similar) to make it easier for Linux users to build. Th